### PR TITLE
Add stimulus-use and refactor the resize controllers

### DIFF
--- a/app/javascript/controllers/resize_height_controller.js
+++ b/app/javascript/controllers/resize_height_controller.js
@@ -1,21 +1,34 @@
 import { Controller } from "@hotwired/stimulus";
 import { FetchRequest } from "@rails/request.js";
+import { useResize, useDebounce } from "stimulus-use";
 
 export default class extends Controller {
-  static values = { url: String, setting: String, height: String }
+  static values = { url: String, setting: String, currentHeight: String }
+  static debounces = ["resize"];
 
-  update(event) {
-    if (this.element != event.target) return;
-    const height = parseInt(this.element.style.height);
-    if (isNaN(height)) return;
+  connect() {
+    useResize(this);
+    useDebounce(this);
+  }
 
+  resize({ height }) {
+    console.log(height);
+    console.log(this.currentHeightValue);
+
+    if (height == this.currentHeightValue) return;
+
+    this.update(height);
+  }
+
+  async update(height) {
     let formData = new FormData();
     formData.append("height", height);
     formData.append("setting", this.settingValue);
 
-    const request = new FetchRequest(
-      "patch", this.urlValue, { body: formData }
-    );
-    request.perform();
+    const request = new FetchRequest("patch", this.urlValue, { body: formData });
+    const response = await request.perform();
+    if (response.ok) {
+      this.currentHeightValue = height;
+    }
   }
 }

--- a/app/views/sample_files/_editor.html.erb
+++ b/app/views/sample_files/_editor.html.erb
@@ -1,7 +1,7 @@
-<%= tag.div class: "bg-[#ccc] rounded flex items-stretch w-full mt-4 min-h-[250px] overflow-y-scroll resize-y pb-3",
+<%= tag.div class: "bg-[#ccc] rounded flex items-stretch w-full mt-4 min-h-[250px] overflow-y-scroll resize-y",
             style: "height: #{editor_height_or_default}px;",
-            data: { controller: "resize-height", action: "click->resize-height#update", resize_height_url_value: resize_path, resize_height_setting_value: "editor_height" } do %>
-  <%= tag.div class: "bg-[#333] rounded-t-l resize-x min-w-[100px] max-w-[400px] overflow-y-scroll",
+            data: { controller: "resize-height", resize_height_url_value: resize_path, resize_height_setting_value: "editor_height", resize_height_current_height_value: editor_height_or_default } do %>
+  <%= tag.div class: "bg-[#333] rounded-t-l resize-x min-w-[100px] max-w-[400px] mb-3 overflow-y-scroll",
               style: "width: #{menu_width_or_default}px;",
               data: { controller: "resize-width", resize_width_url_value: resize_path, resize_width_setting_value: "menu_width", resize_width_current_width_value: menu_width_or_default } do %>
     <%= tag.div class: "px-2 py-6 text-xs text-[#D6D6D6]" do %>
@@ -9,7 +9,7 @@
     <% end %>
   <% end %>
 
-  <%= tag.div class: "bg-[#454545] overflow-y-scroll resize-x",
+  <%= tag.div class: "bg-[#454545] mb-3 overflow-y-scroll resize-x",
               style: "width: #{contents_width_or_default}px;",
               data: { controller: "resize-width", resize_width_url_value: resize_path, resize_width_setting_value: "contents_width", resize_width_current_width_value: contents_width_or_default } do %>
     <%= tag.div class: "p-6 text-sm leading-loose text-white font-recursive-mono" do %>
@@ -17,7 +17,7 @@
     <% end %>
   <% end %>
 
-  <%= tag.div class: "flex-1 bg-white overflow-y-scroll rounded-t-r p-6 text-sm leading-relaxed" do %>
+  <%= tag.div class: "flex-1 bg-white mb-3 overflow-y-scroll rounded-t-r p-6 text-sm leading-relaxed" do %>
     <%= render "sample_files/description", sample_file: sample_file %>
   <% end %>
 <% end %>

--- a/app/views/sample_files/_editor.html.erb
+++ b/app/views/sample_files/_editor.html.erb
@@ -1,16 +1,20 @@
 <%= tag.div class: "bg-[#ccc] rounded flex items-stretch w-full mt-4 min-h-[250px] overflow-y-scroll resize-y pb-3",
             style: "height: #{editor_height_or_default}px;",
             data: { controller: "resize-height", action: "click->resize-height#update", resize_height_url_value: resize_path, resize_height_setting_value: "editor_height" } do %>
-  <%= tag.div class: "bg-[#333] rounded-t-l px-2 py-6 text-xs text-[#D6D6D6] resize-x min-w-[100px] max-w-[400px] overflow-y-scroll",
+  <%= tag.div class: "bg-[#333] rounded-t-l resize-x min-w-[100px] max-w-[400px] overflow-y-scroll",
               style: "width: #{menu_width_or_default}px;",
-              data: { controller: "resize-width", action: "click->resize-width#update", resize_width_url_value: resize_path, resize_width_setting_value: "menu_width" } do %>
-    <%= render "sample_files/menu", sample_files: sample_files %>
+              data: { controller: "resize-width", resize_width_url_value: resize_path, resize_width_setting_value: "menu_width", resize_width_current_width_value: menu_width_or_default } do %>
+    <%= tag.div class: "px-2 py-6 text-xs text-[#D6D6D6]" do %>
+      <%= render "sample_files/menu", sample_files: sample_files %>
+    <% end %>
   <% end %>
 
-  <%= tag.div class: "bg-[#454545] p-6 text-sm leading-loose text-white font-recursive-mono overflow-y-scroll resize-x",
+  <%= tag.div class: "bg-[#454545] overflow-y-scroll resize-x",
               style: "width: #{contents_width_or_default}px;",
-              data: { controller: "resize-width", action: "click->resize-width#update", resize_width_url_value: resize_path, resize_width_setting_value: "contents_width" } do %>
-    <%= render "sample_files/contents", sample_file: sample_file %>
+              data: { controller: "resize-width", resize_width_url_value: resize_path, resize_width_setting_value: "contents_width", resize_width_current_width_value: contents_width_or_default } do %>
+    <%= tag.div class: "p-6 text-sm leading-loose text-white font-recursive-mono" do %>
+      <%= render "sample_files/contents", sample_file: sample_file %>
+    <% end %>
   <% end %>
 
   <%= tag.div class: "flex-1 bg-white overflow-y-scroll rounded-t-r p-6 text-sm leading-relaxed" do %>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "esbuild": "^0.15.5",
     "postcss": "^8.4.16",
     "postcss-cli": "^10.0.0",
+    "stimulus-use": "^0.50.0",
     "tailwindcss": "^3.1.8"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,6 +605,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hotkeys-js@>=3:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.9.5.tgz#8314d0522bf2601e36003213047e9dc7d56d19fe"
+  integrity sha512-T0G8CUZ6Q1IOgPnLK1hDXR8DqgKF/VWEsHvZgi6CM7Ub9oOAzvWuJ3Qhc/9nFQaR26MfFOZSwULHrtCnsUX7zA==
+
 ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
@@ -1142,6 +1147,13 @@ source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
+stimulus-use@^0.50.0:
+  version "0.50.0"
+  resolved "https://registry.yarnpkg.com/stimulus-use/-/stimulus-use-0.50.0.tgz#0bae92fbb1fd961cbb23569f9edd12ae642ce4a6"
+  integrity sha512-9NScZQiOycQdzh8VZ15pxk6ep/a22fgha2halOvZFpJITC4nsTbWlO7D1hm+9LspFxa5b28tQhm3XkbH/qAlGw==
+  dependencies:
+    hotkeys-js ">=3"
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
Somehow, I missed the fact that I could use the [Resize Observer API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) through [Stimulus-Use](https://stimulus-use.github.io/stimulus-use/#/use-resize) for the resize events. (Using click events was pretty hacky.)

I had to move the padding off the resized elements to child elements, because useResize returns the context box width, not the border box width. I had to add debouncing, so it wouldn't continuously call resize. I also needed to set the current size because this approach will report initial size on page load.