### PR TITLE
Fix bug where defaults were 0, set min/max width on contents

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,14 +46,14 @@ module ApplicationHelper
   end
 
   def menu_width_or_default
-    cookies[:menu_width].presence.to_i || 250
+    cookies[:menu_width].presence || 250
   end
 
   def contents_width_or_default
-    cookies[:contents_width].presence.to_i || 650
+    cookies[:contents_width].presence || 650
   end
 
   def editor_height_or_default
-    cookies[:editor_height].presence.to_i || 650
+    cookies[:editor_height].presence || 650
   end
 end

--- a/app/views/sample_files/_editor.html.erb
+++ b/app/views/sample_files/_editor.html.erb
@@ -9,7 +9,7 @@
     <% end %>
   <% end %>
 
-  <%= tag.div class: "bg-[#454545] mb-3 overflow-y-scroll resize-x",
+  <%= tag.div class: "bg-[#454545] mb-3 overflow-y-scroll resize-x min-w-[100px] max-w-[800px]",
               style: "width: #{contents_width_or_default}px;",
               data: { controller: "resize-width", resize_width_url_value: resize_path, resize_width_setting_value: "contents_width", resize_width_current_width_value: contents_width_or_default } do %>
     <%= tag.div class: "p-6 text-sm leading-loose text-white font-recursive-mono" do %>


### PR DESCRIPTION
Calling to_i on nil returns 0, which is not what we want. Need a min and max on the contents, like the sidebar.