### PR TITLE
Add basic file path validation, add styling for Rails .field_with_errors

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,6 +2,8 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+@import "rails.scss";
+
 .font-recursive-mono {
   font-variation-settings: "MONO" 1;
 }

--- a/app/assets/stylesheets/rails.scss
+++ b/app/assets/stylesheets/rails.scss
@@ -1,0 +1,11 @@
+.field_with_errors {
+  @apply inline w-full;
+
+  label {
+    @apply text-red-500;
+  }
+
+  input, select, textarea {
+    @apply border-red-500;
+  }
+}

--- a/app/helpers/tailwind_builder.rb
+++ b/app/helpers/tailwind_builder.rb
@@ -2,7 +2,7 @@
 
 class TailwindBuilder < ActionView::Helpers::FormBuilder
   def default_classes
-    "w-full border-neutral-300 rounded disabled:bg-neutral-100"
+    "w-full border-neutral-300 rounded disabled:bg-neutral-100 placeholder-neutral-300"
   end
 
   def label(method, text = nil, options={})

--- a/app/models/sample_file.rb
+++ b/app/models/sample_file.rb
@@ -1,6 +1,8 @@
 class SampleFile < ApplicationRecord
   belongs_to :sample
 
+  validates :path, presence: true, file_path: true
+
   def lines_or_default
     return 1 if contents.blank?
 

--- a/app/validators/file_path_validator.rb
+++ b/app/validators/file_path_validator.rb
@@ -1,0 +1,16 @@
+class FilePathValidator < ActiveModel::EachValidator
+  FILE_PATH_REGEX = /\A[\w.-][\w.-\/]+[\w.-]\Z/i
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+    return if value =~ FILE_PATH_REGEX
+
+    record.errors.add(attribute, (options[:message] || default_message))
+  end
+
+  private
+
+  def default_message
+    "is not a valid file path"
+  end
+end

--- a/app/views/samples/_sample_file_fields.html.erb
+++ b/app/views/samples/_sample_file_fields.html.erb
@@ -1,7 +1,10 @@
 <%= content_tag :div, class: "nested-form-wrapper bg-[#cecece] p-4 mb-6 rounded", data: { new_record: form.object.new_record? } do %>
   <div class="mb-4 max-w-xl">
     <%= form.label :path %>
-    <%= form.text_field :path %>
+    <div class="flex items-center space-x-2">
+      <div class="shrink-0 text-sm text-neutral-500">Rails.root / </div>
+      <%= form.text_field :path, placeholder: "app/models/user.rb" %>
+    </div>
   </div>
 
   <div class="mb-4">


### PR DESCRIPTION
I couldn't find a great solution for validating fake file paths. I ended up doing a custom regex, but there may be a better option. I also added styling for Rails' provided .field_with_errors. I always forget Rails wraps labels and inputs with the div, which is surprising when styling a view, particularly with flexbox, when expecting that you are always working with direct descendents.