### PR TITLE
Add `bin/dev` script

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! command -v foreman &> /dev/null
+then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
New Rails 7 Applications usually include a `bin/dev` to start up the app 
and all the required proceses with `foreman`, if they are not built with 
import maps. 

This Pull Requests adds this script as it would be found in a new Rails 
7 app with esbuild.