### PR TITLE
Basic user deactivation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,12 @@ class User < ApplicationRecord
   has_one_attached :avatar
 
   validates :username, presence: true, username: true, uniqueness: true
+
+  def active_for_authentication?
+    super && active?
+  end
+
+  def active?
+    deactivated_at.nil?
+  end
 end

--- a/db/migrate/20220907213615_add_deactivated_at_to_users.rb
+++ b/db/migrate/20220907213615_add_deactivated_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeactivatedAtToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :deactivated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_04_195045) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_07_213615) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_04_195045) do
     t.boolean "admin", default: false, null: false
     t.string "username", default: "", null: false
     t.string "unconfirmed_email"
+    t.datetime "deactivated_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Add `deactivated_at` to users and override Devise's `active_for_authentication?` in preparation for bot signups. 🤖