### PR TITLE
Add Aptfile for Heroku vips buildpack

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,3 @@
+libglib2.0-0
+libglib2.0-dev
+libpoppler-glib8


### PR DESCRIPTION
ruby-vips is now the default in Rails 7, but doesn't work out of the box on Heroku. Adding this buildpack, and the necessary Aptfile https://github.com/brandoncc/heroku-buildpack-vips