### PR TITLE
Add Markdown support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "sentry-ruby"
 gem "sentry-rails"
 gem "jsbundling-rails"
 gem "cssbundling-rails"
+gem "redcarpet"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    redcarpet (3.5.1)
     regexp_parser (2.5.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -303,6 +304,7 @@ DEPENDENCIES
   puma (~> 5.0)
   pundit
   rails (~> 7.0.3)
+  redcarpet
   selenium-webdriver
   sentry-rails
   sentry-ruby

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,24 @@
+require 'default_renderer'
+require 'preview_renderer'
+
 module ApplicationHelper
+  def markdown(content)
+    return "" if content.blank?
+
+    sanitize Redcarpet::Markdown.new(
+      DefaultRenderer.new(hard_wrap: true, with_toc_data: true),
+      no_intra_emphasis: true, tables: true, autolink: true,
+      gh_blockcode: true, fenced_code_blocks: true,
+      disable_indented_code_blocks: true
+    ).render(content)
+  end
+
+  def strip_markdown(content)
+    return "" if content.blank?
+
+    Redcarpet::Markdown.new(PreviewRenderer).render(content)
+  end
+
   def user_avatar(user, size: 100)
     if user.avatar.attached?
       user.avatar.variant(resize_to_limit: [size, size])

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -5,7 +5,7 @@
     </div>
 
     <div class="mb-4 text-sm text-neutral-700 h-10 line-clamp-2">
-      <%= category.description %>
+      <%= strip_markdown(category.description).truncate_words(50) %>
     </div>
 
     <div class="text-xs text-neutral-500">

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,4 +1,4 @@
-<% set_meta_tags title: @category.name, description: @category.description %>
+<% set_meta_tags title: @category.name, description: strip_markdown(@category.description) %>
 
 <% content_for(:header) do %>
   <%= render HeaderComponent.new do |c| %>
@@ -19,8 +19,8 @@
 <% if @category.description.present? %>
   <h3 class="text-[#868686] text-sm mb-2">Description</h3>
 
-  <div class="mb-6">
-    <%= @category.description %>
+  <div class="prose prose-blue max-w-4xl mb-6" data-turbo="false">
+    <%= markdown @category.description %>
   </div>
 <% end %>
 

--- a/app/views/sample_files/_description.html.erb
+++ b/app/views/sample_files/_description.html.erb
@@ -1,3 +1,3 @@
-<div>
-  <%= sample_file.description %>
+<div class="prose prose-sm prose-blue" data-turbo="false">
+  <%= markdown sample_file.description %>
 </div>

--- a/app/views/sample_files/show.html.erb
+++ b/app/views/sample_files/show.html.erb
@@ -1,4 +1,4 @@
-<% set_meta_tags title: @sample.title, description: @sample.description %>
+<% set_meta_tags title: @sample.title, description: strip_markdown(@sample.description) %>
 
 <% content_for(:header) do %>
   <%= render HeaderComponent.new do |c| %>
@@ -37,8 +37,8 @@
 <% if @sample.description.present? %>
   <h3 class="text-[#868686] text-sm mb-2">Description</h3>
 
-  <div class="max-w-3xl">
-    <%= @sample.description %>
+  <div class="prose prose-blue max-w-4xl" data-turbo="false">
+    <%= markdown @sample.description %>
   </div>
 <% end %>
 

--- a/app/views/samples/_sample.html.erb
+++ b/app/views/samples/_sample.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <div class="mb-4 text-sm text-neutral-700 h-10 line-clamp-2">
-      <%= sample.description %>
+      <%= strip_markdown(sample.description).truncate_words(50) %>
     </div>
 
     <div class="bg-[#454545] p-4 rounded mb-4 text-xs leading-relaxed text-white font-recursive-mono">

--- a/lib/default_renderer.rb
+++ b/lib/default_renderer.rb
@@ -1,0 +1,3 @@
+class DefaultRenderer < Redcarpet::Render::HTML
+  include Redcarpet::Render::SmartyPants
+end

--- a/lib/preview_renderer.rb
+++ b/lib/preview_renderer.rb
@@ -1,0 +1,11 @@
+require 'redcarpet/render_strip'
+
+class PreviewRenderer < Redcarpet::Render::StripDown
+  def link(link, title, content)
+    content
+  end
+
+  def image(link, title, content)
+    ""
+  end
+end


### PR DESCRIPTION
Add Markdown support for category, sample and sample file descriptions with the https://github.com/vmg/redcarpet gem.